### PR TITLE
Add libyaml-cpp-dev for Debian/Ubuntu/Mint/Pop_OS

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@ make osx
 </h2>
 
 <pre><code>sudo apt-get install build-essential
-sudo apt-get install libsdl2-dev libsdl2-net-dev libssh-dev
+sudo apt-get install libsdl2-dev libsdl2-net-dev libssh-dev libyaml-cpp-dev
 make clean-linux
 make linux
 </code></pre>


### PR DESCRIPTION
I was not able to build from source until I added libyaml-cpp-dev as a dependency on Pop_OS